### PR TITLE
Replaced all uses of rothso with openswoop for the GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project requires **Go**. Their website provides [installers](https://golang
 
 ```shell
 # Install or update
-$ go install github.com/rothso/isqool@latest
+$ go install github.com/openswoop/isqool@latest
 ```
 
 ### Usage

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/rothso/isqool/pkg/database"
-	"github.com/rothso/isqool/pkg/report"
-	"github.com/rothso/isqool/pkg/scrape"
+	"github.com/openswoop/isqool/pkg/database"
+	"github.com/openswoop/isqool/pkg/report"
+	"github.com/openswoop/isqool/pkg/scrape"
 	"log"
 	"os"
 	"regexp"

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/rothso/isqool/pkg/database"
-	"github.com/rothso/isqool/pkg/report"
-	"github.com/rothso/isqool/pkg/scrape"
+	"github.com/openswoop/isqool/pkg/database"
+	"github.com/openswoop/isqool/pkg/report"
+	"github.com/openswoop/isqool/pkg/scrape"
 	"log"
 	"strconv"
 

--- a/pkg/database/bigquery.go
+++ b/pkg/database/bigquery.go
@@ -4,7 +4,7 @@ import (
 	"cloud.google.com/go/bigquery"
 	"context"
 	"fmt"
-	"github.com/rothso/isqool/pkg/scrape"
+	"github.com/openswoop/isqool/pkg/scrape"
 	"google.golang.org/api/googleapi"
 	"strconv"
 	"time"

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1,7 +1,7 @@
 package database
 
 import (
-	"github.com/rothso/isqool/pkg/scrape"
+	"github.com/openswoop/isqool/pkg/scrape"
 	"io"
 )
 

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"github.com/go-gorp/gorp/v3"
 	"github.com/mattn/go-sqlite3"
-	"github.com/rothso/isqool/pkg/scrape"
+	"github.com/openswoop/isqool/pkg/scrape"
 	"log"
 )
 

--- a/pkg/report/course.go
+++ b/pkg/report/course.go
@@ -1,7 +1,7 @@
 package report
 
 import (
-	"github.com/rothso/isqool/pkg/scrape"
+	"github.com/openswoop/isqool/pkg/scrape"
 	"sort"
 )
 

--- a/pkg/report/department.go
+++ b/pkg/report/department.go
@@ -3,7 +3,7 @@ package report
 import (
 	"cloud.google.com/go/bigquery"
 	"fmt"
-	"github.com/rothso/isqool/pkg/scrape"
+	"github.com/openswoop/isqool/pkg/scrape"
 	"strconv"
 )
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -2,7 +2,7 @@ package report
 
 import (
 	"github.com/gocarina/gocsv"
-	"github.com/rothso/isqool/pkg/scrape"
+	"github.com/openswoop/isqool/pkg/scrape"
 	"os"
 )
 


### PR DESCRIPTION
I replaced all the occurences of rothso with openswoop for the GitHub repo page
For example:
github.com/rothso/isqool/pkg/database to github.com/openswoop/isqool/pkg/database